### PR TITLE
fix: add a dummy date

### DIFF
--- a/cmd/changelog/main.go
+++ b/cmd/changelog/main.go
@@ -11,7 +11,7 @@ import (
 var (
 	version = "dev"
 	commit  = "12345678"
-	date    = ""
+	date    = "2006-01-02T15:04:05Z07:00"
 )
 
 func main() {


### PR DESCRIPTION
cmd.NewBuildInfo returns an error if the date is empty and aborts the program. This is the case for users installing the binary with go get.