### PR TITLE
fix: body or footer has a line start with token but no empty before

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -20,6 +20,7 @@ package cc
 import (
 	"bytes"
 	"strings"
+	"regexp"
 
 	"github.com/bbuck/go-lexer"
 )

--- a/parse.go
+++ b/parse.go
@@ -127,5 +127,19 @@ func normalizeNewlines(s string) string {
 	// replace CF \r (mac) with LF \n (unix)
 	d = bytes.ReplaceAll(d, []byte{13}, []byte{10})
 
-	return string(d)
+	return ensureEmptyLineBeforeToken(string(d))
+}
+
+func ensureEmptyLineBeforeToken(s string) string {
+	re := regexp.MustCompile(`^(\w+:\s*)`)
+
+	lines := strings.Split(s, "\n")
+
+	for i, line := range lines {
+		if matches := re.FindStringSubmatch(line); len(matches) > 0 {
+			lines[i] = re.ReplaceAllString(line, "\n$1")
+		}
+	}
+
+	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
- The fix apply only when  the line start with token

The following example was failing with nul, after the proposed fix, it is working.
```
package main

import (
	"encoding/json"
	"fmt"

	"github.com/zbindenren/cc"
)

func main() {
	msg := `feat!: [BQ-627] [Fundamentals Peers] Apply entities permissioning (#55)

When the permissioning system was introduced on the universe, we automatically had permissions applied to all our FUN APIs.

##### Before
What we didn't took into account is that currently, in order to get a company peers we get the top 10 entities (based on the known filter/sorting criterias) and we apply permissions on the top 10 filtered.
ex: if a client is only enabled to XETRA exchange and he will search for APC:DE, we:
- get the top 10 entities worldwide
- out of those top 10 entities we keep only those that have instruments on XETRA

##### After
Instead of applying permissions on the top 10 peers retrieved for the requested entity, first get the entities to which the user is permissioned and get top 10 out of the permissioned ones.
`

	c, _ := cc.Parse(msg)
	d, _ := json.MarshalIndent(c, "", "  ")

	fmt.Println(string(d))
	//fmt.Println(string(c.BreakingMessage()))
	fmt.Println("Hello, World!")
}
```